### PR TITLE
Add test for fromisoformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ the formatters, linters, and test suite.
 ## Contributors
 <!--- Add yourself to the end of the list! -->
 - [Zac Hatfield-Dodds](https://zhd.dev)
+- [Paul Ganssle](https://ganssle.io)

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,3 @@
 # Top-level dependencies for `tox -e test`
-hypothesis
+hypothesis[dateutil]
 hypothesmith

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@
 #    tox -e deps
 #
 attrs==19.3.0             # via hypothesis
-hypothesis==5.3.1
+hypothesis[dateutil]==5.4.0
 hypothesmith==0.0.5
 lark-parser==0.8.1        # via hypothesmith
+python-dateutil==2.8.1    # via hypothesis
+six==1.14.0               # via python-dateutil
 sortedcontainers==2.1.0   # via hypothesis

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,6 +1,25 @@
 import unittest
+from datetime import datetime, timezone
+
+from hypothesis import given, settings, strategies as st
+from hypothesis.extra.dateutil import timezones as dateutil_timezones
+
+TIME_ZONES_STRATEGY = st.one_of(
+    st.sampled_from([None, timezone.utc]), dateutil_timezones()
+)
 
 
 class TestDatetime(unittest.TestCase):
     # TODO: https://docs.python.org/3/library/datetime.html
-    pass
+
+    # The search space here is large and as of January 2020 the sampling
+    # functions for characters() and datetimes() are not biased towards
+    # "interesting" examples, so it's worth throwing some extra cycles at this.
+    @settings(max_examples=2500)
+    @given(dt=st.datetimes(timezones=TIME_ZONES_STRATEGY), sep=st.characters())
+    def test_fromisoformat_auto(self, dt, sep):
+        """Test isoformat with timespec="auto"."""
+        dtstr = dt.isoformat(sep=sep, timespec="auto")
+        dt_rt = datetime.fromisoformat(dtstr)
+
+        self.assertEqual(dt, dt_rt)


### PR DESCRIPTION
This is adapted from a test I used when originally developing `fromisoformat`, and tests the basic contract.

Possibly the most controversial aspect of this is that it requires pulling in `dateutil` to get real time zone data, though we could probably come up with a composite strategy that makes a slightly weaker guarantee using only the Standard Library modules (at least until zoneinfo support lands in Python).