### PR TITLE
add a simple round-trip test for marshal.loads/dumps

### DIFF
--- a/tests/test_marshal.py
+++ b/tests/test_marshal.py
@@ -1,0 +1,40 @@
+import marshal
+import unittest
+
+from hypothesis import example, given, strategies as st
+
+simple_immutables = (
+    st.integers()
+    | st.booleans()
+    | st.floats(allow_nan=False)
+    | st.complex_numbers(allow_nan=False)
+    | st.just(None)
+    | st.binary()
+    | st.text()
+)
+composite_immutables = st.recursive(
+    simple_immutables,
+    lambda children: st.tuples(children) | st.frozensets(children, max_size=1),
+    max_leaves=20,
+)
+
+
+def marshallable_data(children):
+    return st.lists(children, max_size=20) | st.dictionaries(
+        composite_immutables, children
+    )
+
+
+marshallable_data = st.recursive(
+    composite_immutables | st.sets(composite_immutables),
+    marshallable_data,
+    max_leaves=20,
+)
+
+
+class TestMarshal(unittest.TestCase):
+    @given(dt=marshallable_data)
+    def test_roundtrip(self, dt):
+        b = marshal.dumps(dt)
+        dt2 = marshal.loads(b)  # noqa: S302  # using marshal is fine here
+        self.assertEqual(dt, dt2)

--- a/tests/test_marshal.py
+++ b/tests/test_marshal.py
@@ -1,12 +1,12 @@
 import marshal
 import unittest
 
-from hypothesis import example, given, strategies as st
+from hypothesis import given, strategies as st
 
 simple_immutables = (
     st.integers()
     | st.booleans()
-    | st.floats(allow_nan=False)
+    | st.floats(allow_nan=False)  # NaNs compare unequal to themselves
     | st.complex_numbers(allow_nan=False)
     | st.just(None)
     | st.binary()


### PR DESCRIPTION
generates tuples, frozensets, sets, lists and dicts of primitive data.
So far no code objects are generated, because they have very different
constructors on different versions of Python.

I also tried to test the property that calling dumps again would generate the same binary data, but it turns out that that is not true:

https://twitter.com/cfbolz/status/1234816498201436160

I'm planning to add some more tests along these lines, maybe porting a few of the PyPy randomized tests. Does that make sense to you?