### PR TITLE
add pypy3 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,13 @@ python:
   - "3.8"
   - "3.8-dev"
   - "nightly"
-  - "pypy3"
 install:
   - pip install tox
 script:
   - tox --recreate
   - git diff --exit-code
+# pypy3 is currently Python 3.6, so skip the formatting checks
+jobs:
+  include:
+  - python: "pypy3"
+    script: "tox -re test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.8"
   - "3.8-dev"
   - "nightly"
+  - "pypy3"
 install:
   - pip install tox
 script:

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -13,6 +13,7 @@ class TestDatetime(unittest.TestCase):
     # Surrogate characters have been particularly problematic here in the past,
     # so we give them a boost by combining strategies pending an upstream
     # feature (https://github.com/HypothesisWorks/hypothesis/issues/1401)
+    @unittest.skipIf(not hasattr(datetime, "fromisoformat"), reason="new in 3.7")
     @given(
         dt=st.datetimes(timezones=TIME_ZONES_STRATEGY),
         sep=st.characters() | st.characters(whitelist_categories=["Cs"]),


### PR DESCRIPTION
It's again not clear to me whether you actually want to merge this, but it would be cool if we could also run the tests on pypy3 on Travis.

Pros:
- it would be a lot less work for us PyPy devs later to pass all the tests if this repo takes off, usually small incompatibilities/implementation specific behaviour always sneaks into a test suite
- we'd find bugs in PyPy too, potentially

Cons:
- More work for people doing pull requests
- PyPy3 only supports version 3.6 so far