### PR TITLE
WIP: Round trip tests for `colorsys` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Bugs found via this specific project:
   [a `fold` inconsistency](https://github.com/pganssle/zoneinfo/pull/41)
   where first offset handling was broken in the C extension.
 - Catastrophic loss of precision when attempting to round-trip YIQ-RGB-YIQ
-  with the `colorsys` module - `> 0.24` on a `[0, 1]` range.  (via #13)
+  with the `colorsys` module - more than 10% of the possible range.  (via #13)
 
 
 ## Further reading

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Bugs found via this specific project:
   seconds is too large to fit in a C integer; and
   [a `fold` inconsistency](https://github.com/pganssle/zoneinfo/pull/41)
   where first offset handling was broken in the C extension.
+- Catastrophic loss of precision when attempting to round-trip YIQ-RGB-YIQ
+  with the `colorsys` module - `> 0.24` on a `[0, 1]` range.  (via #13)
 
 
 ## Further reading

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -33,12 +33,18 @@ class TestColorsys(unittest.TestCase):
     # conversion.  We're using the `@unittest.expectedFailure` decorator
     # to silence this for now, but will report it on bugs.python.org too.
     # Highest observed target scores:
-    #     0.247024  (label='absolute difference in Q values')
-    #     0.247234  (label='absolute difference in Y values')
-    #     0.341794  (label='absolute difference in I values')
+    #     0.0653745  (label='absolute difference in I values')
+    #     0.107538   (label='absolute difference in Y values')
+    #     0.197426   (label='absolute difference in Q values')
     @unittest.expectedFailure
+    # Allowed ranges for I and Q values are not documented in CPython
+    # https://docs.python.org/3/library/colorsys.html - and code comments
+    # note "I and Q ... covers a slightly larger range [than `[0, 1`]".
+    # We therefore follow https://en.wikipedia.org/wiki/YIQ#Preconditions
     @given(
-        y=st.floats(0.0, 1.0), i=st.floats(-0.523, 0.523), q=st.floats(-0.596, 0.596),
+        y=st.floats(0.0, 1.0),
+        i=st.floats(-0.5957, 0.5957),
+        q=st.floats(-0.5226, 0.5226),
     )
     def test_yiq_rgb_round_trip(self, y, i, q):
         r, g, b = colorsys.yiq_to_rgb(y, i, q)

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -16,7 +16,43 @@ class TestBinASCII(unittest.TestCase):
 
 
 class TestColorsys(unittest.TestCase):
-    # TODO: https://docs.python.org/3/library/colorsys.html
+    # Module documentation https://docs.python.org/3/library/colorsys.html
+    @given(
+        r=st.floats(0.0, 1.0), g=st.floats(0.0, 1.0), b=st.floats(0.0, 1.0),
+    )
+    def test_rgb_yiq_round_trip(self, r, g, b):
+        y, i, q = colorsys.rgb_to_yiq(r, g, b)
+        r2, g2, b2 = colorsys.yiq_to_rgb(y, i, q)
+
+        self.assertAlmostEqual(r, r2)
+        self.assertAlmostEqual(g, g2)
+        self.assertAlmostEqual(b, b2)
+
+    # TODO: Test fails y=0.0, i=0.0, q=1.3331280799455672e-07
+    # AssertionError: 0.0 != 5.0000000042300254e-08 within 7 places
+
+    @given(
+        y=st.floats(0.0, 1.0), i=st.floats(-0.523, 0.523), q=st.floats(-0.596, 0.596),
+    )
+    def test_yiq_rgb_round_trip(self, y, i, q):
+        r, g, b = colorsys.yiq_to_rgb(y, i, q)
+        y2, i2, q2 = colorsys.rgb_to_yiq(r, g, b)
+
+        self.assertAlmostEqual(y, y2)
+        self.assertAlmostEqual(i, i2)
+        self.assertAlmostEqual(q, q2)
+
+    @given(
+        r=st.floats(0.0, 1.0), g=st.floats(0.0, 1.0), b=st.floats(0.0, 1.0),
+    )
+    def test_rgb_hls_round_trip(self, r, g, b):
+        h, l, s = colorsys.rgb_to_hls(r, g, b)
+        r2, g2, b2 = colorsys.hls_to_rgb(h, l, s)
+
+        self.assertAlmostEqual(r, r2)
+        self.assertAlmostEqual(g, g2)
+        self.assertAlmostEqual(b, b2)
+
     @given(
         r=st.floats(0.0, 1.0), g=st.floats(0.0, 1.0), b=st.floats(0.0, 1.0),
     )

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -1,5 +1,6 @@
 import quopri
 import unittest
+import colorsys
 
 from hypothesis import given, strategies as st
 
@@ -16,7 +17,19 @@ class TestBinASCII(unittest.TestCase):
 
 class TestColorsys(unittest.TestCase):
     # TODO: https://docs.python.org/3/library/colorsys.html
-    pass
+    @given(
+        r=st.floats(0.0, 1.0),
+        g=st.floats(0.0, 1.0),
+        b=st.floats(0.0, 1.0),
+        h=st.floats(0.0, 1.0),
+        s=st.floats(0.0, 1.0),
+        v=st.floats(0.0, 1.0),
+    )
+    def test_rgb_hsv_round_trip(self, r, g, b, h, s, v):
+        hsv = colorsys.rgb_to_hsv(r, g, b)
+        rgb = colorsys.hsv_to_rgb(hsv[0], hsv[1], hsv[2])
+
+        self.assertSequenceEqual((r, g, b), rgb)
 
 
 class TestPlistlib(unittest.TestCase):

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -29,7 +29,7 @@ class TestColorsys(unittest.TestCase):
         hsv = colorsys.rgb_to_hsv(r, g, b)
         rgb = colorsys.hsv_to_rgb(hsv[0], hsv[1], hsv[2])
 
-        self.assertSequenceEqual((r, g, b), rgb)
+        self.assertTupleEqual((r, g, b), rgb)
 
 
 class TestPlistlib(unittest.TestCase):

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -18,29 +18,34 @@ class TestBinASCII(unittest.TestCase):
 class TestColorsys(unittest.TestCase):
     # Module documentation https://docs.python.org/3/library/colorsys.html
 
-    @given(
-        r=st.floats(0.0, 1.0), g=st.floats(0.0, 1.0), b=st.floats(0.0, 1.0),
-    )
+    def assertColorsValid(self, **colors):
+        assert len(colors) == 3  # sanity-check
+        # Our color assertion helper checks that each color is in the range
+        # [0, 1], and that it approximately round-tripped.  We also "target"
+        # the difference, to maximise and report the largest error each run.
+        for name, values in colors.items():
+            for v in values:
+                self.assertGreaterEqual(
+                    v, 0 if name not in "iq" else -1, msg=f"color={name!r}"
+                )
+                self.assertLessEqual(v, 1, msg=f"color={name!r}")
+            target(
+                abs(values[0] - values[1]),
+                label=f"absolute difference in {name.upper()} values",
+            )
+            self.assertAlmostEqual(*values, msg=f"color={name!r}")
+
+    @given(r=st.floats(0, 1), g=st.floats(0, 1), b=st.floats(0, 1))
     def test_rgb_yiq_round_trip(self, r, g, b):
         y, i, q = colorsys.rgb_to_yiq(r, g, b)
         r2, g2, b2 = colorsys.yiq_to_rgb(y, i, q)
+        self.assertColorsValid(r=(r, r2), g=(g, g2), b=(b, b2))
 
-        self.assertAlmostEqual(r, r2)
-        self.assertAlmostEqual(g, g2)
-        self.assertAlmostEqual(b, b2)
-
-    # This appears to be a genuine and serious bug in YIQ/RBG/YIQ color
-    # conversion.  We're using the `@unittest.expectedFailure` decorator
-    # to silence this for now, but will report it on bugs.python.org too.
-    # Highest observed target scores:
-    #     0.0653745  (label='absolute difference in I values')
-    #     0.107538   (label='absolute difference in Y values')
-    #     0.197426   (label='absolute difference in Q values')
-    @unittest.expectedFailure
     # Allowed ranges for I and Q values are not documented in CPython
     # https://docs.python.org/3/library/colorsys.html - and code comments
-    # note "I and Q ... covers a slightly larger range [than `[0, 1`]".
+    # note "I and Q ... covers a slightly larger range [than `[0, 1`]]".
     # We therefore follow https://en.wikipedia.org/wiki/YIQ#Preconditions
+    @unittest.expectedFailure
     @given(
         y=st.floats(0.0, 1.0),
         i=st.floats(-0.5957, 0.5957),
@@ -49,35 +54,26 @@ class TestColorsys(unittest.TestCase):
     def test_yiq_rgb_round_trip(self, y, i, q):
         r, g, b = colorsys.yiq_to_rgb(y, i, q)
         y2, i2, q2 = colorsys.rgb_to_yiq(r, g, b)
+        self.assertColorsValid(y=(y, y2), i=(i, i2), q=(q, q2))
 
-        target(abs(y - y2), label="absolute difference in Y values")
-        target(abs(i - i2), label="absolute difference in I values")
-        target(abs(q - q2), label="absolute difference in Q values")
-        self.assertAlmostEqual(y, y2)
-        self.assertAlmostEqual(i, i2)
-        self.assertAlmostEqual(q, q2)
-
-    @given(
-        r=st.floats(0.0, 1.0), g=st.floats(0.0, 1.0), b=st.floats(0.0, 1.0),
-    )
+    @given(r=st.floats(0, 1), g=st.floats(0, 1), b=st.floats(0, 1))
     def test_rgb_hls_round_trip(self, r, g, b):
         h, l, s = colorsys.rgb_to_hls(r, g, b)
         r2, g2, b2 = colorsys.hls_to_rgb(h, l, s)
+        self.assertColorsValid(r=(r, r2), g=(g, g2), b=(b, b2))
 
-        self.assertAlmostEqual(r, r2)
-        self.assertAlmostEqual(g, g2)
-        self.assertAlmostEqual(b, b2)
+        h2, l2, s2 = colorsys.rgb_to_hls(r2, g2, b2)
+        self.assertColorsValid(h=(h, h2), l=(l, l2), s=(s, s2))
 
-    @given(
-        r=st.floats(0.0, 1.0), g=st.floats(0.0, 1.0), b=st.floats(0.0, 1.0),
-    )
+    @unittest.expectedFailure
+    @given(r=st.floats(0, 1), g=st.floats(0, 1), b=st.floats(0, 1))
     def test_rgb_hsv_round_trip(self, r, g, b):
         h, s, v = colorsys.rgb_to_hsv(r, g, b)
         r2, g2, b2 = colorsys.hsv_to_rgb(h, s, v)
+        self.assertColorsValid(r=(r, r2), g=(g, g2), b=(b, b2))
 
-        self.assertAlmostEqual(r, r2)
-        self.assertAlmostEqual(g, g2)
-        self.assertAlmostEqual(b, b2)
+        h2, s2, v2 = colorsys.rgb_to_hls(r2, g2, b2)
+        self.assertColorsValid(h=(h, h2), s=(s, s2), v=(v, v2))
 
 
 class TestPlistlib(unittest.TestCase):

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -1,6 +1,6 @@
+import colorsys
 import quopri
 import unittest
-import colorsys
 
 from hypothesis import given, strategies as st
 
@@ -18,18 +18,15 @@ class TestBinASCII(unittest.TestCase):
 class TestColorsys(unittest.TestCase):
     # TODO: https://docs.python.org/3/library/colorsys.html
     @given(
-        r=st.floats(0.0, 1.0),
-        g=st.floats(0.0, 1.0),
-        b=st.floats(0.0, 1.0),
-        h=st.floats(0.0, 1.0),
-        s=st.floats(0.0, 1.0),
-        v=st.floats(0.0, 1.0),
+        r=st.floats(0.0, 1.0), g=st.floats(0.0, 1.0), b=st.floats(0.0, 1.0),
     )
-    def test_rgb_hsv_round_trip(self, r, g, b, h, s, v):
-        hsv = colorsys.rgb_to_hsv(r, g, b)
-        rgb = colorsys.hsv_to_rgb(hsv[0], hsv[1], hsv[2])
+    def test_rgb_hsv_round_trip(self, r, g, b):
+        h, s, v = colorsys.rgb_to_hsv(r, g, b)
+        r2, g2, b2 = colorsys.hsv_to_rgb(h, s, v)
 
-        self.assertTupleEqual((r, g, b), rgb)
+        self.assertAlmostEqual(r, r2)
+        self.assertAlmostEqual(g, g2)
+        self.assertAlmostEqual(b, b2)
 
 
 class TestPlistlib(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
 
 # Settings for other tools
 [flake8]
-ignore = E501,W503,S101,S310
+ignore = E501,W503,S101,S310,N802
 exclude = .*/,__pycache__
 
 [isort]


### PR DESCRIPTION
Hello @Zac-HD, here's my first attempt at writing a test for `colorsys` module, starting with a round trip test for `rgb_to_hsv()` and `hsv_to_rgb()`. This is a draft because the test is failing right now and I'm not sure why...

I do have some questions:

- is it possible to specify increments of floats generated by `st.floats()`? It seems like valid inputs for the `colorsys` functions only have one decimal point (e.g., 0.1, 0.2).
- since the functions being tested return tuples of floats, is `assertTupleEqual` the appropriate assert method? 