### PR TITLE
WIP - Test cases for base64 module

### DIFF
--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -5,10 +5,11 @@ import unittest
 from hypothesis import given, strategies as st
 
 
-# function which adds padding, till len(payload) is a multiple of 4
+# function which adds padding, to make len(payload) a multiple of 4
 def add_padding(payload):
-    padding = b"\0" * ((-len(payload)) % 4)
-    payload = payload + padding
+    if len(payload) % 4 != 0:
+        padding = b"\0" * ((-len(payload)) % 4)
+        payload = payload + padding
     return payload
 
 

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -14,11 +14,6 @@ def add_padding(payload):
 
 
 class TestBase64(unittest.TestCase):
-    # @given(
-    #     payload=st.binary(),
-    #     altchars=(st.none() | st.binary(min_size=2, max_size=2)),
-    #     validate=st.booleans(),
-    # )
     @given(
         payload=st.binary(),
         altchars=(st.none() | st.just(b"_-")),

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -5,11 +5,29 @@ import unittest
 from hypothesis import given, strategies as st
 
 
+# function which adds padding, till len(payload) is a multiple of 4
+def add_padding(payload):
+    padding = b"\0" * ((-len(payload)) % 4)
+    payload = payload + padding
+    return payload
+
+
 class TestBase64(unittest.TestCase):
-    @given(payload=st.binary())
-    def test_b64_encode_decode_round_trip(self, payload):
-        x = base64.b64encode(payload)
-        self.assertEqual(payload, base64.b64decode(x))
+    # @given(
+    #     payload=st.binary(),
+    #     altchars=(st.none() | st.binary(min_size=2, max_size=2)),
+    #     validate=st.booleans(),
+    # )
+    @given(
+        payload=st.binary(),
+        altchars=(st.none() | st.just(b"_-")),
+        validate=st.booleans(),
+    )
+    def test_b64_encode_decode_round_trip(self, payload, altchars, validate):
+        x = base64.b64encode(payload, altchars=altchars)
+        self.assertEqual(
+            payload, base64.b64decode(x, altchars=altchars, validate=validate)
+        )
 
     @given(payload=st.binary())
     def test_standard_b64_encode_decode_round_trip(self, payload):
@@ -21,41 +39,46 @@ class TestBase64(unittest.TestCase):
         x = base64.urlsafe_b64encode(payload)
         self.assertEqual(payload, base64.urlsafe_b64decode(x))
 
-    @given(payload=st.binary())
-    def test_b32_encode_decode_round_trip(self, payload):
+    @given(
+        payload=st.binary(),
+        casefold=st.booleans(),
+        map01=(st.none() | st.binary(min_size=1, max_size=1)),
+    )
+    def test_b32_encode_decode_round_trip(self, payload, casefold, map01):
         x = base64.b32encode(payload)
-        self.assertEqual(payload, base64.b32decode(x))
+        self.assertEqual(payload, base64.b32decode(x, casefold=casefold, map01=map01))
 
-    @given(payload=st.binary())
-    def test_b16_encode_decode_round_trip(self, payload):
+    @given(payload=st.binary(), casefold=st.booleans())
+    def test_b16_encode_decode_round_trip(self, payload, casefold):
         x = base64.b16encode(payload)
-        self.assertEqual(payload, base64.b16decode(x))
+        self.assertEqual(payload, base64.b16decode(x, casefold=casefold))
 
     @given(
         payload=st.binary(),
         foldspaces=st.booleans(),
-        wrapcol=st.integers(0, 10),
+        wrapcol=(st.just(0) | st.integers(0, 1000)),
+        pad=st.booleans(),
         adobe=st.booleans(),
     )
-    def test_a85_encode_decode_round_trip(self, payload, foldspaces, wrapcol, adobe):
+    def test_a85_encode_decode_round_trip(
+        self, payload, foldspaces, wrapcol, pad, adobe
+    ):
         x = base64.a85encode(
-            payload, foldspaces=foldspaces, wrapcol=wrapcol, adobe=adobe
+            payload, foldspaces=foldspaces, wrapcol=wrapcol, pad=pad, adobe=adobe
         )
+        # adding padding manually to payload, when pad is True and len(payload)%4!=0
+        if pad:
+            payload = add_padding(payload)
         self.assertEqual(
             payload, base64.a85decode(x, foldspaces=foldspaces, adobe=adobe)
         )
 
-    @given(payload=st.binary())
-    def test_b85_encode_decode_round_trip(self, payload):
-        x = base64.b85encode(payload)
-        self.assertEqual(payload, base64.b85decode(x))
-
-    # this is failing for payload = b'\x00'
-    # expected to remove padding implicitly
-    @unittest.expectedFailure
-    @given(payload=st.binary())
-    def test_b85_encode_with_padding_decode_round_trip(self, payload):
-        x = base64.b85encode(payload, True)
+    @given(payload=st.binary(), pad=st.booleans())
+    def test_b85_encode_decode_round_trip(self, payload, pad):
+        x = base64.b85encode(payload, pad=pad)
+        # adding padding manually to payload, when pad is True and len(payload)%4!=0
+        if pad:
+            payload = add_padding(payload)
         self.assertEqual(payload, base64.b85decode(x))
 
 

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -31,10 +31,19 @@ class TestBase64(unittest.TestCase):
         x = base64.b16encode(payload)
         self.assertEqual(payload, base64.b16decode(x))
 
-    @given(payload=st.binary(), adobe=st.booleans())
-    def test_a85_encode_decode_round_trip(self, payload, adobe):
-        x = base64.a85encode(payload, foldspaces=True, adobe=adobe)
-        self.assertEqual(payload, base64.a85decode(x, foldspaces=False, adobe=adobe))
+    @given(
+        payload=st.binary(),
+        foldspaces=st.booleans(),
+        wrapcol=st.integers(0, 10),
+        adobe=st.booleans(),
+    )
+    def test_a85_encode_decode_round_trip(self, payload, foldspaces, wrapcol, adobe):
+        x = base64.a85encode(
+            payload, foldspaces=foldspaces, wrapcol=wrapcol, adobe=adobe
+        )
+        self.assertEqual(
+            payload, base64.a85decode(x, foldspaces=foldspaces, adobe=adobe)
+        )
 
     @given(payload=st.binary())
     def test_b85_encode_decode_round_trip(self, payload):

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -1,3 +1,4 @@
+import base64
 import quopri
 import unittest
 
@@ -5,8 +6,48 @@ from hypothesis import given, strategies as st
 
 
 class TestBase64(unittest.TestCase):
-    # TODO: https://docs.python.org/3/library/base64.html
-    pass
+    @given(payload=st.binary())
+    def test_b64_encode_decode_round_trip(self, payload):
+        x = base64.b64encode(payload)
+        self.assertEqual(payload, base64.b64decode(x))
+
+    @given(payload=st.binary())
+    def test_standard_b64_encode_decode_round_trip(self, payload):
+        x = base64.standard_b64encode(payload)
+        self.assertEqual(payload, base64.standard_b64decode(x))
+
+    @given(payload=st.binary())
+    def test_urlsafe_b64_encode_decode_round_trip(self, payload):
+        x = base64.urlsafe_b64encode(payload)
+        self.assertEqual(payload, base64.urlsafe_b64decode(x))
+
+    @given(payload=st.binary())
+    def test_b32_encode_decode_round_trip(self, payload):
+        x = base64.b32encode(payload)
+        self.assertEqual(payload, base64.b32decode(x))
+
+    @given(payload=st.binary())
+    def test_b16_encode_decode_round_trip(self, payload):
+        x = base64.b16encode(payload)
+        self.assertEqual(payload, base64.b16decode(x))
+
+    @given(payload=st.binary(), adobe=st.booleans())
+    def test_a85_encode_decode_round_trip(self, payload, adobe):
+        x = base64.a85encode(payload, foldspaces=True, adobe=adobe)
+        self.assertEqual(payload, base64.a85decode(x, foldspaces=False, adobe=adobe))
+
+    @given(payload=st.binary())
+    def test_b85_encode_decode_round_trip(self, payload):
+        x = base64.b85encode(payload)
+        self.assertEqual(payload, base64.b85decode(x))
+
+    # this is failing for payload = b'\x00'
+    # expected to remove padding implicitly
+    @unittest.expectedFailure
+    @given(payload=st.binary())
+    def test_b85_encode_with_padding_decode_round_trip(self, payload):
+        x = base64.b85encode(payload, True)
+        self.assertEqual(payload, base64.b85decode(x))
 
 
 class TestBinASCII(unittest.TestCase):


### PR DESCRIPTION
@Zac-HD I have made an attempt to add a few test cases for the `base64` module.

I had a doubt - This particular test case `test_b85_encode_with_padding_decode_round_trip`, is failing for `payload = b'\x00'`. I set `pad = True` while `b85encode`. The expectation is that `b85decode`, will implicitly remove the padding, but it fails to decode. Let me know your thoughts.
```   
 def test_b85_encode_with_padding_decode_round_trip(self, payload):
        x = base64.b85encode(payload, True)
        self.assertEqual(payload, base64.b85decode(x))
```