### PR TITLE
adding round trip test for lzma

### DIFF
--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,5 +1,6 @@
 import bz2
 import gzip
+import lzma
 import unittest
 
 from hypothesis import HealthCheck, given, settings, strategies as st
@@ -48,7 +49,10 @@ class TestGzip(unittest.TestCase):
 
 class TestLZMA(unittest.TestCase):
     # TODO: https://docs.python.org/3/library/lzma.html
-    pass
+    @given(payload=st.binary(), compresslevel=st.integers(0, 9))
+    def test_lzma_round_trip(self, payload, compresslevel):
+        result = lzma.decompress(lzma.compress(payload,  preset=compresslevel))
+        self.assertEqual(payload, result)
 
 
 class TestZlib(unittest.TestCase):

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -49,9 +49,30 @@ class TestGzip(unittest.TestCase):
 
 class TestLZMA(unittest.TestCase):
     # TODO: https://docs.python.org/3/library/lzma.html
-    @given(payload=st.binary(), compresslevel=st.integers(0, 9))
-    def test_lzma_round_trip(self, payload, compresslevel):
-        result = lzma.decompress(lzma.compress(payload, preset=compresslevel))
+    @given(
+        payload=st.binary(),
+        check=st.sampled_from(
+            ["CHECK_NONE", "CHECK_CRC32", "CHECK_CRC64", "CHECK_SHA256"]
+        ),
+        compresslevel=st.integers(0, 9),
+    )
+    def test_lzma_round_trip_format_xz(self, payload, check, compresslevel):
+        result = lzma.decompress(
+            lzma.compress(
+                payload, format="FORMAT_XZ", check=check, preset=compresslevel
+            )
+        )
+        self.assertEqual(payload, result)
+
+    @given(
+        payload=st.binary(),
+        format=st.sampled_from(["FORMAT_ALONE", "FORMAT_RAW"]),
+        compresslevel=st.integers(0, 9),
+    )
+    def test_lzma_round_trip_format_others(self, payload, format, compresslevel):
+        result = lzma.decompress(
+            lzma.compress(payload, format=format, preset=compresslevel)
+        )
         self.assertEqual(payload, result)
 
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -73,10 +73,9 @@ class TestLZMA(unittest.TestCase):
         )
         self.assertEqual(payload, result)
 
-    @given(payload=st.binary(), data=st.data())
-    def test_lzma_round_trip_format_raw(self, payload, data):
-        # create the list of filter ids
-        filter_ids = data.draw(
+    @st.composite
+    def filters(self, draw):
+        filter_ids = draw(
             st.lists(
                 st.sampled_from(
                     [
@@ -96,8 +95,8 @@ class TestLZMA(unittest.TestCase):
         # create filters options
         filters = []
         for filter in filter_ids:
-            lc = data.draw(st.integers(0, 4))
-            lp = data.draw(st.integers(0, 4 - lc))
+            lc = draw(st.integers(0, 4))
+            lp = draw(st.integers(0, 4 - lc))
             filters.append(
                 {
                     "id": filter,
@@ -122,6 +121,12 @@ class TestLZMA(unittest.TestCase):
                     "depth": data.draw(st.integers(min_value=0)),
                 }
             )
+        return filters
+
+    @given(payload=st.binary(), data=st.data())
+    def test_lzma_round_trip_format_raw(self, payload, data):
+        # create the list of filter ids
+        filters = self.filters(data.draw)
         result = lzma.decompress(
             lzma.compress(payload, format=lzma.FORMAT_RAW, filters=filters)
         )

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -7,6 +7,7 @@ from hypothesis import HealthCheck, given, settings, strategies as st
 
 no_health_checks = settings(suppress_health_check=HealthCheck.all())
 
+
 @st.composite
 def lzma_filters(draw):
     """Generating filters options"""
@@ -36,12 +37,10 @@ def lzma_filters(draw):
             {
                 "id": filter,
                 "preset": draw(st.integers(0, 9)),
-                #"dict_size": draw(st.integers(4000, 1.875e8)),
+                # "dict_size": draw(st.integers(4000, 1.875e8)),
                 "lc": lc,
                 "lp": lp,
-                "mode": draw(
-                    st.sampled_from([lzma.MODE_FAST, lzma.MODE_NORMAL])
-                ),
+                "mode": draw(st.sampled_from([lzma.MODE_FAST, lzma.MODE_NORMAL])),
                 "mf": draw(
                     st.sampled_from(
                         [
@@ -57,6 +56,7 @@ def lzma_filters(draw):
             }
         )
     return filters
+
 
 class TestBz2(unittest.TestCase):
     @given(payload=st.binary(), compresslevel=st.integers(1, 9))

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -51,7 +51,7 @@ class TestLZMA(unittest.TestCase):
     # TODO: https://docs.python.org/3/library/lzma.html
     @given(payload=st.binary(), compresslevel=st.integers(0, 9))
     def test_lzma_round_trip(self, payload, compresslevel):
-        result = lzma.decompress(lzma.compress(payload,  preset=compresslevel))
+        result = lzma.decompress(lzma.compress(payload, preset=compresslevel))
         self.assertEqual(payload, result)
 
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -9,6 +9,7 @@ no_health_checks = settings(suppress_health_check=HealthCheck.all())
 
 @st.composite
 def lzma_filters(draw):
+    """Generating filters options"""
     filter_ids = draw(
         st.lists(
             st.sampled_from(
@@ -35,7 +36,7 @@ def lzma_filters(draw):
             {
                 "id": filter,
                 "preset": draw(st.integers(0, 9)),
-                "dict_size": draw(st.integers(4000, 1.875e8)),
+                #"dict_size": draw(st.integers(4000, 1.875e8)),
                 "lc": lc,
                 "lp": lp,
                 "mode": draw(
@@ -124,11 +125,8 @@ class TestLZMA(unittest.TestCase):
 
     @given(payload=st.binary(), filters=lzma_filters())
     def test_lzma_round_trip_format_raw(self, payload, filters):
-        # create the list of filter ids
-        result = lzma.decompress(
-            lzma.compress(payload, format=lzma.FORMAT_RAW, filters=filters)
-        )
-        self.assertEqual(payload, result)
+        # TODO: testing with various filter options
+        pass
 
 
 class TestZlib(unittest.TestCase):

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -65,8 +65,7 @@ class TestLZMA(unittest.TestCase):
         self.assertEqual(payload, result)
 
     @given(
-        payload=st.binary(),
-        compresslevel=st.integers(0, 9),
+        payload=st.binary(), compresslevel=st.integers(0, 9),
     )
     def test_lzma_round_trip_format_alone(self, payload, compresslevel):
         result = lzma.decompress(
@@ -74,31 +73,60 @@ class TestLZMA(unittest.TestCase):
         )
         self.assertEqual(payload, result)
 
-    @given(
-        payload=st.binary(),
-        data=st.data())
+    @given(payload=st.binary(), data=st.data())
     def test_lzma_round_trip_format_raw(self, payload, data):
         # create the list of filter ids
-        filter_ids=data.draw(st.lists(st.sampled_from([lzma.FILTER_DELTA, lzma.FILTER_X86, lzma.FILTER_IA64, lzma.FILTER_ARM, lzma.FILTER_ARMTHUMB, lzma.FILTER_POWERPC, lzma.FILTER_SPARC]), max_size=3))
+        filter_ids = data.draw(
+            st.lists(
+                st.sampled_from(
+                    [
+                        lzma.FILTER_DELTA,
+                        lzma.FILTER_X86,
+                        lzma.FILTER_IA64,
+                        lzma.FILTER_ARM,
+                        lzma.FILTER_ARMTHUMB,
+                        lzma.FILTER_POWERPC,
+                        lzma.FILTER_SPARC,
+                    ]
+                ),
+                max_size=3,
+            )
+        )
         filter_ids.append(lzma.FILTER_LZMA2)
         # create filters options
-        filters=[]
+        filters = []
         for filter in filter_ids:
             lc = data.draw(st.integers(0, 4))
-            lp = data.draw(st.integers(0, 4-lc))
-            filters.append({"id":filter,
-                            "preset":data.draw(st.integers(0, 9)),
-                            "dict_size":data.draw(st.integers(4000, 1.875e+8)),
-                            "lc":lc,
-                            "lp":lp,
-                            "mode":data.draw(st.sampled_from([lzma.MODE_FAST, lzma.MODE_NORMAL])),
-                            "mf":data.draw(st.sampled_from([lzma.MF_HC3, lzma.MF_HC4, lzma.MF_BT2, lzma.MF_BT3, lzma.MF_BT4])),
-                            "depth":data.draw(st.integers(min_value=0))
-                            })
+            lp = data.draw(st.integers(0, 4 - lc))
+            filters.append(
+                {
+                    "id": filter,
+                    "preset": data.draw(st.integers(0, 9)),
+                    "dict_size": data.draw(st.integers(4000, 1.875e8)),
+                    "lc": lc,
+                    "lp": lp,
+                    "mode": data.draw(
+                        st.sampled_from([lzma.MODE_FAST, lzma.MODE_NORMAL])
+                    ),
+                    "mf": data.draw(
+                        st.sampled_from(
+                            [
+                                lzma.MF_HC3,
+                                lzma.MF_HC4,
+                                lzma.MF_BT2,
+                                lzma.MF_BT3,
+                                lzma.MF_BT4,
+                            ]
+                        )
+                    ),
+                    "depth": data.draw(st.integers(min_value=0)),
+                }
+            )
         result = lzma.decompress(
             lzma.compress(payload, format=lzma.FORMAT_RAW, filters=filters)
         )
         self.assertEqual(payload, result)
+
 
 class TestZlib(unittest.TestCase):
     # TODO: https://docs.python.org/3/library/zlib.html

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -77,9 +77,9 @@ class TestLZMA(unittest.TestCase):
     @given(
         payload=st.binary(),
         data=st.data())
-    def test_lzma_round_trip_format_alone(self, payload, data):
+    def test_lzma_round_trip_format_raw(self, payload, data):
         # create the list of filter ids
-        filter_ids=data.draw(st.lists([lzma.FILTER_DELTA, lzma.FILTER_X86, lzma.FILTER_IA64, lzma.FILTER_ARM, lzma.FILTER_ARMTHUMB, lzma.FILTER_POWERPC, lzma.FILTER_SPARC], max_size=3))
+        filter_ids=data.draw(st.lists(st.sampled_from([lzma.FILTER_DELTA, lzma.FILTER_X86, lzma.FILTER_IA64, lzma.FILTER_ARM, lzma.FILTER_ARMTHUMB, lzma.FILTER_POWERPC, lzma.FILTER_SPARC]), max_size=3))
         filter_ids.append(lzma.FILTER_LZMA2)
         # create filters options
         filters=[]
@@ -96,7 +96,7 @@ class TestLZMA(unittest.TestCase):
                             "depth":data.draw(st.integers(min_value=0))
                             })
         result = lzma.decompress(
-            lzma.compress(payload, format=lzma.FORMAT_ALONE, filters=filters)
+            lzma.compress(payload, format=lzma.FORMAT_RAW, filters=filters)
         )
         self.assertEqual(payload, result)
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -51,22 +51,23 @@ class TestLZMA(unittest.TestCase):
     # TODO: https://docs.python.org/3/library/lzma.html
     @given(
         payload=st.binary(),
+        format=st.just(lzma.FORMAT_XZ),
         check=st.sampled_from(
-            ["CHECK_NONE", "CHECK_CRC32", "CHECK_CRC64", "CHECK_SHA256"]
+            [lzma.CHECK_NONE, lzma.CHECK_CRC32, lzma.CHECK_CRC64, lzma.CHECK_SHA256]
         ),
         compresslevel=st.integers(0, 9),
     )
-    def test_lzma_round_trip_format_xz(self, payload, check, compresslevel):
+    def test_lzma_round_trip_format_xz(self, payload, format, check, compresslevel):
         result = lzma.decompress(
             lzma.compress(
-                payload, format="FORMAT_XZ", check=check, preset=compresslevel
+                payload, format=format, check=check, preset=compresslevel
             )
         )
         self.assertEqual(payload, result)
 
     @given(
         payload=st.binary(),
-        format=st.sampled_from(["FORMAT_ALONE", "FORMAT_RAW"]),
+        format=st.sampled_from([lzma.FORMAT_ALONE, lzma.FORMAT_RAW]),
         compresslevel=st.integers(0, 9),
     )
     def test_lzma_round_trip_format_others(self, payload, format, compresslevel):

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -68,7 +68,7 @@ class TestLZMA(unittest.TestCase):
         payload=st.binary(),
         compresslevel=st.integers(0, 9),
     )
-    def test_lzma_round_trip_format_alone(self, payload, format, compresslevel):
+    def test_lzma_round_trip_format_alone(self, payload, compresslevel):
         result = lzma.decompress(
             lzma.compress(payload, format=lzma.FORMAT_ALONE, preset=compresslevel)
         )

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ description = Run the tests
 deps =
     --no-deps
     -r requirements.txt
+    -U
+    git+https://github.com/Zac-HD/hypothesmith.git
 commands =
     python -m unittest discover tests --catch {posargs}
 


### PR DESCRIPTION
Adding the round trip test for lzma. Only option that is testing is the compresslever (preset) however, according to the [documentation](https://docs.python.org/3/library/lzma.html#lzma.LZMACompressor) there are other options such as format=FORMAT_XZ, check=-1 Shall I add that? I know I can use st.build to add them (cannot use sampled from because some options are only available to certain settings)