### PR TITLE
Added roundtrip test for plistlib

### DIFF
--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -259,6 +259,8 @@ text_strategy = st.text(alphabet=st.characters(blacklist_categories=["Cc", "Cs"]
 
 plistlib_data = st.recursive(
     st.booleans()
+    | st.binary()
+    | st.datetimes().map(lambda d: d.replace(microsecond=0))
     | st.integers(min_value=-1 << 63, max_value=1 << 64 - 1)
     | st.floats(allow_nan=False)
     | text_strategy,

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -273,7 +273,7 @@ class TestPlistlib(unittest.TestCase):
     @settings(suppress_health_check=HealthCheck.all())
     @given(
         payload=plistlib_data,
-        fmt=st.just(plistlib.FMT_XML) | st.just(plistlib.FMT_BINARY),
+        fmt=st.sampled_from([plistlib.FMT_XML, plistlib.FMT_BINARY]),
         pass_format_arg=st.booleans(),
     )
     def test_dumps_loads(self, payload, fmt, pass_format_arg):

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -277,12 +277,9 @@ class TestPlistlib(unittest.TestCase):
         pass_format_arg=st.booleans(),
     )
     def test_dumps_loads(self, payload, fmt, pass_format_arg):
-        if pass_format_arg:
-            plist_dump = plistlib.dumps(payload, fmt=fmt)
-            self.assertEqual(payload, plistlib.loads(plist_dump, fmt=fmt))
-        else:
-            plist_dump = plistlib.dumps(payload)
-            self.assertEqual(payload, plistlib.loads(plist_dump))
+        plist_dump = plistlib.dumps(payload, fmt=fmt)
+        plist_load = plistlib.loads(plist_dump, fmt=fmt if pass_format_arg else None)
+        self.assertEqual(payload, plist_load)
 
 
 class TestQuopri(unittest.TestCase):


### PR DESCRIPTION
Resolves https://github.com/Zac-HD/stdlib-property-tests/issues/19

@Zac-HD here are a few points,

1. I have used `st.floats(allow_nan=False)`, since `self.assertEqual(nan, nan)` was failing. 
2. I have used `st.integers(min_value=-1 << 63, max_value=1 << 64 - 1)`, since `plistlib` was throwing `OverflowError` otherwise.
3. I have used `st.text(alphabet=st.characters(blacklist_categories=["Cc", "Cs"]))`, since `plistlib` was throwing a error if the text contained control characters.